### PR TITLE
Make the plugin work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "htest.dev": "^0.0.16",
+        "htest.dev": "latest",
         "prettier": "^3.4.2"
       },
       "peerDependencies": {
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/htest.dev": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/htest.dev/-/htest.dev-0.0.16.tgz",
-      "integrity": "sha512-4rwoAD60/utYWOWQlf8Ew3j1q5SFTNRIezE2KKy9ggri1i1kWu5Xf5BKg18sIfvXzekGSEiHFTuMEeybMWm5zA==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/htest.dev/-/htest.dev-0.0.17.tgz",
+      "integrity": "sha512-/kFSxuGAuit0ByVBz2gSZXqUn7S/h/voMItMdm4MZznnB0wUeqGh+PIEeMfnt+1HFSKoLyKxSMInnJEJQKRI9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     ".": "./index.js"
   },
   "scripts": {
-    "test": "htest test.mjs"
+    "test": "htest test.js"
   },
   "keywords": [],
   "author": "Lea Verou",
@@ -14,7 +14,7 @@
   "type": "module",
   "description": "",
   "devDependencies": {
-    "htest.dev": "^0.0.16",
+    "htest.dev": "latest",
     "prettier": "^3.4.2"
   },
   "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,16 +1,15 @@
-
 import prettier from "prettier";
 
-// Custom Prettier config with your plugin
+// Custom Prettier config with our plugin
 const config = {
 	plugins: ["./index.js"],
 	parser: "babel",
 	useTabs: true,
 };
 
-const t = {
+export default {
 	run: arg => prettier.format(arg, config),
-	map: code => code + "\n",
+	map: code => code.endsWith("\n") ? code : code + "\n", // Append a new line to the expected value (the actual result already has one)
 	tests: [
 		{
 			name: "Changed",
@@ -22,6 +21,11 @@ const t = {
 				{
 					arg: "class Foo {\n\tmethod(a, b) {\n\t\treturn a + b;\n\t}\n}",
 					expect: "class Foo {\n\tmethod (a, b) {\n\t\treturn a + b;\n\t}\n}",
+				},
+				{
+					name: "Getters and Setters",
+					arg: "class Foo {\n\tget method() {\n\t\treturn true;\n\t}\n}",
+					expect: "class Foo {\n\tget method () {\n\t\treturn true;\n\t}\n}",
 				},
 				{
 					name: "Anonymous function (Prettier default)",
@@ -46,27 +50,4 @@ const t = {
 			]
 		}
 	]
-}
-
-export default t;
-
-// hTest is not currently working properly for promises
-for (let test in t.tests) {
-	let tests = t.tests[test];
-
-	for (let subtest in tests.tests) {
-		const st = tests.tests[subtest];
-		const arg = st.arg + "\n";
-		const expect = st.expect + "\n";
-		const result = await t.run(arg);
-		const passed = result === expect;
-
-		if (passed) {
-			const name = st.name || st.arg;
-			console.log(`✅ ${name}` + (st.arg === st.expect ? ' (unchanged)' : ''));
-		}
-		else {
-			console.log(`❌ ${st.name ? st.name + ": " : ""}Got ${st.arg === result ? 'no change' : result}, expected ${st.expect}`);
-		}
-	}
 }


### PR DESCRIPTION
* The plugin doesn't contribute any new languages, so we don't need to export the corresponding constant

* To use a custom printer, we need to provide the `parsers` constant

* Babel produces AST of the `estree` format (even though we might give it any name, let's use the default one)

* Use the latest version of hTest

* Add a test for getters and setters