### PR TITLE
Next iteration

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,7 @@ import babelPlugin from "prettier/plugins/babel";
 import estreePlugin from "prettier/plugins/estree";
 
 export const parsers = {
-	babel: {
-		...babelPlugin.parsers.babel,
-		astFormat: "estree",
-	},
+	...babelPlugin.parsers,
 };
 
 export const printers = {

--- a/index.js
+++ b/index.js
@@ -20,5 +20,32 @@ export const printers = {
 
 			return estreePlugin.printers.estree.print(path, options, print);
 		},
+
+		// Comments are not part of an AST and are handled separately
+		// See https://prettier.io/docs/en/plugins#handling-comments-in-a-printer
+		printComment (commentPath, options) {
+			return estreePlugin.printers.estree.printComment(commentPath, options);
+		},
+
+		canAttachComment (node) {
+			return node.type && node.type !== "Comment";
+		},
+
+		isBlockComment (node) {
+			return node.type === "CommentBlock";
+		},
+
+		// Use Prettier's default comment attachment algorithm
+		handleComments: {
+			ownLine (comment, text, options, ast, isLastComment) {
+				return false;
+			},
+			endOfLine (comment, text, options, ast, isLastComment) {
+				return false;
+			},
+			remaining (comment, text, options, ast, isLastComment) {
+				return false;
+			},
+		},
 	},
 };


### PR DESCRIPTION
Changes:
- Support other parsers provided by the Babel plugin (all of them produce an AST of the `estree` format, so we don't need to define it explicitly)
- Properly handle comments. Thanks to @MysteryBlokHed for [pointing out the issue](https://github.com/color-js/color.js/pull/626#issuecomment-2591402113).

I used these tests but did not include them in the test suite because they don't add any new functionality to the plugin:
```js
// Other tests
{
	name: "Inline comment",
	arg: "// Function call\ntest(1, 2);",
	expect: "// Function call\ntest(1, 2);",
},
{
	name: "Block comment",
	arg: "/* First line\nSecond line */\ntest(1, 2);",
	expect: "/* First line\nSecond line */\ntest(1, 2);",
},
```