### PR TITLE
Cover more cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,70 @@ function* test () {
 }
 ```
 
+### Named exported functions
+
+```js
+export function test(a, b) {
+	return a + b;
+}
+```
+
+becomes:
+
+```js
+export function test (a, b) {
+	return a + b;
+}
+```
+
+### Default exported functions
+
+```js
+export default function test(a, b) {
+	return a + b;
+}
+```
+
+becomes:
+
+```js
+export default function test (a, b) {
+	return a + b;
+}
+```
+
+### Async exported functions
+
+```js
+export async function test(a, b) {
+	return a + b;
+}
+```
+
+becomes:
+
+```js
+export async function test (a, b) {
+	return a + b;
+}
+```
+
+### Generator exported functions
+
+```js
+export function* test() {
+	yield 1;
+}
+```
+
+becomes:
+
+```js
+export function* test () {
+	yield 1;
+}
+```
+
 
 ## What remains unchanged in JavaScript
 
@@ -517,6 +581,82 @@ class Foo {
 }
 ```
 
+### Abstract class methods
+
+```ts
+abstract class Foo {
+	abstract method(a: number, b: number): number;
+}
+```
+
+becomes:
+
+```ts
+abstract class Foo {
+	abstract method (a: number, b: number): number;
+}
+```
+
+### Private class methods
+
+```ts
+class Foo {
+	private method(a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	private method (a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+### Protected class methods
+
+```ts
+class Foo {
+	protected method(a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	protected method (a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+### Public class methods
+
+```ts
+class Foo {
+	public method(a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	public method (a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
 ### Class getters
 
 ```ts
@@ -587,6 +727,102 @@ becomes:
 interface Foo {
 	method (a: number, b: number): number;
 }
+```
+
+### Named exported functions
+
+```ts
+export function test(a: number, b: number): number {
+	return a + b;
+}
+```
+
+becomes:
+
+```ts
+export function test (a: number, b: number): number {
+	return a + b;
+}
+```
+
+### Default exported functions
+
+```ts
+export default function test(a: number, b: number): number {
+	return a + b;
+}
+```
+
+becomes:
+
+```ts
+export default function test (a: number, b: number): number {
+	return a + b;
+}
+```
+
+### Async exported functions
+
+```ts
+export async function test(a: number, b: number): Promise<number> {
+	return a + b;
+}
+```
+
+becomes:
+
+```ts
+export async function test (a: number, b: number): Promise<number> {
+	return a + b;
+}
+```
+
+### Generator exported functions
+
+```ts
+export function* test(): Generator<number> {
+	yield 1;
+}
+```
+
+becomes:
+
+```ts
+export function* test (): Generator<number> {
+	yield 1;
+}
+```
+
+### Exported function in namespace
+
+```ts
+declare namespace Foo {
+	export function test(a: number, b: number): number;
+}
+```
+
+becomes:
+
+```ts
+declare namespace Foo {
+	export function test (a: number, b: number): number;
+}
+```
+
+### Function type aliases
+
+```ts
+type MethodType = {
+	method(): void;
+};
+```
+
+becomes:
+
+```ts
+type MethodType = {
+	method (): void;
+};
 ```
 
 
@@ -664,3 +900,4 @@ Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
 - Function with type parameters (a.k.a. generic functions)
+- Computed method names (in classes and objects)

--- a/README.src.md
+++ b/README.src.md
@@ -31,3 +31,4 @@ Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
 - Function with type parameters (a.k.a. generic functions)
+- Computed method names (in classes and objects)

--- a/index.js
+++ b/index.js
@@ -25,11 +25,14 @@ export const printers = {
 				"ClassMethod",
 				// TypeScript node types
 				"TSMethodSignature",
+				"TSDeclareFunction",
+				"TSAbstractMethodDefinition",
 			].includes(node.type) || 
 			// Handle object methods in TypeScript
 			(node.type === "Identifier" && parent?.type === "Property" && (parent.method || parent.kind))) {
-				if (node.typeParameters) {
-					// TODO: Add space after the closing bracket
+				if (node.typeParameters || node.computed) {
+					// TODO: Add space after the closing bracket, not name
+					// We should get `[methodName] () {...}`, not `[methodName ] () {...}`
 					// We should get `foo<T> () {...}`, not `foo <T> {...}`
 				}
 				else {

--- a/test.js
+++ b/test.js
@@ -41,6 +41,12 @@ export default {
 							expect: "const foo = {\n\tasync method (a, b) {\n\t\treturn a + b;\n\t}\n};",
 						},
 						{
+							name: "Computed object methods",
+							arg: "const foo = {\n\t[methodName]() {}\n};",
+							expect: "const foo = {\n\t[methodName] () {}\n};",
+							skip: true,
+						},
+						{
 							name: "Object getters",
 							arg: "const foo = {\n\tget foo() {\n\t\treturn true;\n\t}\n};",
 							expect: "const foo = {\n\tget foo () {\n\t\treturn true;\n\t}\n};",
@@ -66,6 +72,12 @@ export default {
 							expect: "class Foo {\n\tasync method (a, b) {\n\t\treturn a + b;\n\t}\n}",
 						},
 						{
+							name: "Computed class methods",
+							arg: "class Foo {\n\t[methodName]() {}\n}",
+							expect: "class Foo {\n\t[methodName] () {}\n}",
+							skip: true,
+						},
+						{
 							name: "Static class methods",
 							arg: "class Foo {\n\tstatic method(a, b) {\n\t\treturn a + b;\n\t}\n}",
 							expect: "class Foo {\n\tstatic method (a, b) {\n\t\treturn a + b;\n\t}\n}",
@@ -84,6 +96,26 @@ export default {
 							name: "Generator functions",
 							arg: "function* test() {\n\tyield 1;\n}",
 							expect: "function* test () {\n\tyield 1;\n}",
+						},
+						{
+							name: "Named exported functions",
+							arg: "export function test(a, b) {\n\treturn a + b;\n}",
+							expect: "export function test (a, b) {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Default exported functions",
+							arg: "export default function test(a, b) {\n\treturn a + b;\n}",
+							expect: "export default function test (a, b) {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Async exported functions",
+							arg: "export async function test(a, b) {\n\treturn a + b;\n}",
+							expect: "export async function test (a, b) {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Generator exported functions",
+							arg: "export function* test() {\n\tyield 1;\n}",
+							expect: "export function* test () {\n\tyield 1;\n}",
 						},
 					],
 				},
@@ -140,6 +172,12 @@ export default {
 							expect: "const foo = {\n\tasync method (a: number, b: number): Promise<number> {\n\t\treturn a + b;\n\t}\n};",
 						},
 						{
+							name: "Computed object methods",
+							arg: "const foo = {\n\t[methodName](): void {}\n};",
+							expect: "const foo = {\n\t[methodName] (): void {}\n};",
+							skip: true,
+						},
+						{
 							name: "Object getters",
 							arg: "const foo = {\n\tget foo(): boolean {\n\t\treturn true;\n\t}\n};",
 							expect: "const foo = {\n\tget foo (): boolean {\n\t\treturn true;\n\t}\n};",
@@ -170,6 +208,26 @@ export default {
 							expect: "class Foo {\n\tstatic method (a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
 						},
 						{
+							name: "Abstract class methods",
+							arg: "abstract class Foo {\n\tabstract method(a: number, b: number): number;\n}",
+							expect: "abstract class Foo {\n\tabstract method (a: number, b: number): number;\n}",
+						},
+						{
+							name: "Private class methods",
+							arg: "class Foo {\n\tprivate method(a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+							expect: "class Foo {\n\tprivate method (a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+						},
+						{
+							name: "Protected class methods",
+							arg: "class Foo {\n\tprotected method(a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+							expect: "class Foo {\n\tprotected method (a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+						},
+						{
+							name: "Public class methods",
+							arg: "class Foo {\n\tpublic method(a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+							expect: "class Foo {\n\tpublic method (a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
+						},
+						{
 							name: "Class getters",
 							arg: "class Foo {\n\tget foo(): boolean {\n\t\treturn true;\n\t}\n}",
 							expect: "class Foo {\n\tget foo (): boolean {\n\t\treturn true;\n\t}\n}",
@@ -178,6 +236,12 @@ export default {
 							name: "Class setters",
 							arg: "class Foo {\n\tset foo(value: boolean) {\n\t\tthis._foo = value;\n\t}\n}",
 							expect: "class Foo {\n\tset foo (value: boolean) {\n\t\tthis._foo = value;\n\t}\n}",
+						},
+						{
+							name: "Computed class methods",
+							arg: "class Foo {\n\t[methodName](): void {}\n}",
+							expect: "class Foo {\n\t[methodName] (): void {}\n}",
+							skip: true,
 						},
 						{
 							name: "Generator functions",
@@ -194,6 +258,36 @@ export default {
 							arg: "function foo<T>(arg: T): T {\n\treturn arg;\n}",
 							expect: "function foo<T> (arg: T): T {\n\treturn arg;\n}",
 							skip: true,
+						},
+						{
+							name: "Named exported functions",
+							arg: "export function test(a: number, b: number): number {\n\treturn a + b;\n}",
+							expect: "export function test (a: number, b: number): number {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Default exported functions",
+							arg: "export default function test(a: number, b: number): number {\n\treturn a + b;\n}",
+							expect: "export default function test (a: number, b: number): number {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Async exported functions",
+							arg: "export async function test(a: number, b: number): Promise<number> {\n\treturn a + b;\n}",
+							expect: "export async function test (a: number, b: number): Promise<number> {\n\treturn a + b;\n}",
+						},
+						{
+							name: "Generator exported functions",
+							arg: "export function* test(): Generator<number> {\n\tyield 1;\n}",
+							expect: "export function* test (): Generator<number> {\n\tyield 1;\n}",
+						},
+						{
+							name: "Exported function in namespace",
+							arg: "declare namespace Foo {\n\texport function test(a: number, b: number): number;\n}",
+							expect: "declare namespace Foo {\n\texport function test (a: number, b: number): number;\n}",
+						},
+						{
+							name: "Function type aliases",
+							arg: "type MethodType = {\n\tmethod(): void;\n};",
+							expect: "type MethodType = {\n\tmethod (): void;\n};",
 						},
 					],
 				},


### PR DESCRIPTION
- Exported functions in TypeScript interfaces (all other cases seem supported by the current version)
- `abstract` methods in TypeScript
- One more niche thing not covered yet—computed method names