### PR TITLE
Cover more cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,5 +1027,4 @@ let a = { value: null, prev: null, next: null as never };
 Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
-- Function with type parameters (a.k.a. generic functions)
-- Computed method names (in classes and objects)
+- Computed object method names in TS

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ const foo = {
 };
 ```
 
+### Computed object methods
+
+```js
+const foo = {
+	[methodName]() {
+		return 42;
+	}
+};
+```
+
+becomes:
+
+```js
+const foo = {
+	[methodName] () {
+		return 42;
+	}
+};
+```
+
 ### Object getters
 
 ```js
@@ -196,6 +216,26 @@ becomes:
 class Foo {
 	async method (a, b) {
 		return a + b;
+	}
+}
+```
+
+### Computed class methods
+
+```js
+class Foo {
+	[methodName]() {
+		return 42;
+	}
+}
+```
+
+becomes:
+
+```js
+class Foo {
+	[methodName] () {
+		return 42;
 	}
 }
 ```
@@ -657,6 +697,26 @@ class Foo {
 }
 ```
 
+### Optional class methods
+
+```ts
+class Foo {
+	method?(a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	method? (a: number, b: number): number {
+		return a + b;
+	}
+}
+```
+
 ### Class getters
 
 ```ts
@@ -697,6 +757,46 @@ class Foo {
 }
 ```
 
+### Computed class methods
+
+```ts
+class Foo {
+	[methodName](): void {
+		return;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	[methodName] (): void {
+		return;
+	}
+}
+```
+
+### Class methods with type parameters
+
+```ts
+class Foo {
+	method<T>(a: T): T {
+		return a;
+	}
+}
+```
+
+becomes:
+
+```ts
+class Foo {
+	method<T> (a: T): T {
+		return a;
+	}
+}
+```
+
 ### Generator functions
 
 ```ts
@@ -726,6 +826,22 @@ becomes:
 ```ts
 interface Foo {
 	method (a: number, b: number): number;
+}
+```
+
+### Function with type parameters
+
+```ts
+function foo<T>(arg: T): T {
+	return arg;
+}
+```
+
+becomes:
+
+```ts
+function foo<T> (arg: T): T {
+	return arg;
 }
 ```
 
@@ -891,6 +1007,18 @@ becomes:
 
 ```ts
 type Func = { (a: string): number };
+```
+
+### Object literal
+
+```ts
+let a = { value: null, prev: null, next: null as never };
+```
+
+becomes:
+
+```ts
+let a = { value: null, prev: null, next: null as never };
 ```
 
 

--- a/README.src.md
+++ b/README.src.md
@@ -30,5 +30,4 @@ All you need to do is actually include it in your Prettier config:
 Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
-- Function with type parameters (a.k.a. generic functions)
-- Computed method names (in classes and objects)
+- Computed object method names in TS

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 import babelPlugin from "prettier/plugins/babel";
 import estreePlugin from "prettier/plugins/estree";
 import typescriptPlugin from "prettier/plugins/typescript";
+import { builders } from "prettier/doc";
+
+const { group } = builders;
 
 export const parsers = {
 	...babelPlugin.parsers,
@@ -41,12 +44,12 @@ export const printers = {
 				let contents = findContents(doc);
 				if (contents) {
 					// Open paren is always the second item in the contents array
-					contents[1] = " (";
+					contents[1] = group([" ", "("]);
 				}
 				else if (node.type === "Identifier" && !parent?.computed) {
 					// Object method in TypeScript. `doc` is already an array where the first item is the method name.
 					// TODO: Properly handle computed object methods. We should get `[methodName] () {...}`, not `[methodName ] () {...}`
-					doc[0] += " ";
+					doc[0] = group([doc[0], " "]);
 				}
 
 				return doc;

--- a/index.js
+++ b/index.js
@@ -30,21 +30,55 @@ export const printers = {
 			].includes(node.type) || 
 			// Handle object methods in TypeScript
 			(node.type === "Identifier" && parent?.type === "Property" && (parent.method || parent.kind === "get" || parent.kind === "set"))) {
-				if (node.typeParameters || node.computed || node.optional) {
-					// TODO: Add space after the closing bracket and/or question mark, not name
-					// We should get `[methodName] () {...}`, not `[methodName ] () {...}`
-					// We should get `foo<T> () {...}`, not `foo <T> {...}`
-					// We should get `foo? () {...}`, not `foo ?() {...}`
+				// Skip anonymous functions (they are already formatted properly)
+				if (node.type === "FunctionExpression" && !node.id) {
+					return estreePlugin.printers.estree.print(path, options, print);
 				}
-				else {
-					node = node.type === "Identifier" ? node : node.id ?? node.key;
-					if (node?.name) {
-						node.name += " ";
-					}
+
+				let doc = estreePlugin.printers.estree.print(path, options, print);
+
+				// Find the first "(" and add a space before it
+				let contents = findContents(doc);
+				if (contents) {
+					// Open paren is always the second item in the contents array
+					contents[1] = " (";
 				}
+				else if (node.type === "Identifier" && !parent?.computed) {
+					// Object method in TypeScript. `doc` is already an array where the first item is the method name.
+					// TODO: Properly handle computed object methods. We should get `[methodName] () {...}`, not `[methodName ] () {...}`
+					doc[0] += " ";
+				}
+
+				return doc;
 			}
 
 			return estreePlugin.printers.estree.print(path, options, print);
 		},
 	},
 };
+
+// Recursively find the (possibly nested) array with the first "(" in the doc produced by prettier
+function findContents (doc) {
+	if (!doc) {
+		return null;
+	}
+
+	if (doc.type === "group") {
+		return findContents(doc.contents);
+	}
+
+	if (Array.isArray(doc)) {
+		if (doc.includes("(")) {
+			return doc;
+		}
+
+		for (let item of doc) {
+			let contents = findContents(item);
+			if (contents) {
+				return contents;
+			}
+		}
+	}
+
+	return null;
+}

--- a/test.js
+++ b/test.js
@@ -42,9 +42,8 @@ export default {
 						},
 						{
 							name: "Computed object methods",
-							arg: "const foo = {\n\t[methodName]() {}\n};",
-							expect: "const foo = {\n\t[methodName] () {}\n};",
-							skip: true,
+							arg: "const foo = {\n\t[methodName]() {\n\t\treturn 42;\n\t}\n};",
+							expect: "const foo = {\n\t[methodName] () {\n\t\treturn 42;\n\t}\n};",
 						},
 						{
 							name: "Object getters",
@@ -73,9 +72,8 @@ export default {
 						},
 						{
 							name: "Computed class methods",
-							arg: "class Foo {\n\t[methodName]() {}\n}",
-							expect: "class Foo {\n\t[methodName] () {}\n}",
-							skip: true,
+							arg: "class Foo {\n\t[methodName]() {\n\t\treturn 42;\n\t}\n}",
+							expect: "class Foo {\n\t[methodName] () {\n\t\treturn 42;\n\t}\n}",
 						},
 						{
 							name: "Static class methods",
@@ -173,8 +171,8 @@ export default {
 						},
 						{
 							name: "Computed object methods",
-							arg: "const foo = {\n\t[methodName](): void {}\n};",
-							expect: "const foo = {\n\t[methodName] (): void {}\n};",
+							arg: "const foo = {\n\t[methodName](): void {\n\t\treturn;\n\t}\n};",
+							expect: "const foo = {\n\t[methodName] (): void {\n\t\treturn;\n\t}\n};",
 							skip: true,
 						},
 						{
@@ -231,7 +229,6 @@ export default {
 							name: "Optional class methods",
 							arg: "class Foo {\n\tmethod?(a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
 							expect: "class Foo {\n\tmethod? (a: number, b: number): number {\n\t\treturn a + b;\n\t}\n}",
-							skip: true,
 						},
 						{
 							name: "Class getters",
@@ -245,15 +242,13 @@ export default {
 						},
 						{
 							name: "Computed class methods",
-							arg: "class Foo {\n\t[methodName](): void {}\n}",
-							expect: "class Foo {\n\t[methodName] (): void {}\n}",
-							skip: true,
+							arg: "class Foo {\n\t[methodName](): void {\n\t\treturn;\n\t}\n}",
+							expect: "class Foo {\n\t[methodName] (): void {\n\t\treturn;\n\t}\n}",
 						},
 						{
 							name: "Class methods with type parameters",
 							arg: "class Foo {\n\tmethod<T>(a: T): T {\n\t\treturn a;\n\t}\n}",
 							expect: "class Foo {\n\tmethod<T> (a: T): T {\n\t\treturn a;\n\t}\n}",
-							skip: true,
 						},
 						{
 							name: "Generator functions",
@@ -269,7 +264,6 @@ export default {
 							name: "Function with type parameters",
 							arg: "function foo<T>(arg: T): T {\n\treturn arg;\n}",
 							expect: "function foo<T> (arg: T): T {\n\treturn arg;\n}",
-							skip: true,
 						},
 						{
 							name: "Named exported functions",


### PR DESCRIPTION
The main change is that we shouldn't mutate the AST itself. Instead, we should adjust the result produced by the corresponding printer (this is precisely what the `print` method is for—produce the structure that Prettier can later correctly handle).

This change covers all the existing cases and the ones that were previously skipped (mostly prettifying TS files).

There is only one case left—computed object methods in TS. I still feel that it's quite a niche case. We can probably handle it in the next iteration.