### PR TITLE
[patch] Skip decorated class methods in TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,3 +1222,4 @@ Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
 - Computed object method names in TS
+- Decorated class methods in TS

--- a/README.src.md
+++ b/README.src.md
@@ -31,3 +31,4 @@ Current version is a proof of concept, please try it out and give feedback!
 
 Things not handled yet:
 - Computed object method names in TS
+- Decorated class methods in TS

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ export const printers = {
 			// Handle object methods in TypeScript
 			(node.type === "Identifier" && parent?.type === "Property" && (parent.method || parent.kind === "get" || parent.kind === "set"))) {
 				// Skip anonymous functions (they are already formatted properly)
+				// and decorated class methods (for now, they break the code badly)
 				if (
+					node.decorators?.length ||
 					(node.type === "FunctionExpression" || node.type === "FunctionDeclaration") &&
 					!node.id
 				) {

--- a/test.js
+++ b/test.js
@@ -341,6 +341,12 @@ export default {
 							arg: "type MethodType = {\n\tmethod(): void;\n};",
 							expect: "type MethodType = {\n\tmethod (): void;\n};",
 						},
+						{
+							name: "Decorated class methods",
+							arg: "class Foo {\n\t@decorator(() => {})\n\tmethod(): void {}\n}",
+							expect: "class Foo {\n\t@decorator(() => {})\n\tmethod (): void {}\n}",
+							skip: true,
+						},
 					],
 				},
 				{


### PR DESCRIPTION
They break the formatted code badly (see #15), and fixing it isn't straightforward (at least now, I don't see an effective way to do it).

Releasing the patch, we can allow people to keep using the plugin without breaking their code (until they stumble upon another bug 😅).